### PR TITLE
Update canvas layers to use offscreen canvases.  #Closes 17

### DIFF
--- a/src/app/components/canvas-layers/abstract-canvas-layer.component.ts
+++ b/src/app/components/canvas-layers/abstract-canvas-layer.component.ts
@@ -8,10 +8,12 @@ export abstract class AbstractCanvasLayerComponent implements AfterViewInit {
     @Input() zIndex?: number;
     @Input() bground?: string;
 
-    private ctx!: CanvasRenderingContext2D | null;
     protected drawableList: Drawable[];
     protected updateDrawableList: Drawable[];
     protected canvas!: HTMLCanvasElement;
+    private ctx!: CanvasRenderingContext2D | null;
+    protected offscreen!: OffscreenCanvas;
+    private offscreenCtx!: OffscreenCanvasRenderingContext2D | null;
     protected forceClear: boolean;
 
     constructor() {
@@ -25,9 +27,11 @@ export abstract class AbstractCanvasLayerComponent implements AfterViewInit {
      * Should be called in the subclass's AfterViewInit hook.
      * @param canvasRef HTMLCanvasElement reference for the layer
      */
-    protected initCanvas(canvasRef: ElementRef<HTMLCanvasElement>) {
+    protected initCanvas(offscreen: OffscreenCanvas, canvasRef: ElementRef<HTMLCanvasElement>) {
         this.canvas = canvasRef.nativeElement;
         this.ctx = this.canvas.getContext('2d');
+        this.offscreen = offscreen;
+        this.offscreenCtx = this.offscreen.getContext('2d');
     }
 
     /**
@@ -36,6 +40,7 @@ export abstract class AbstractCanvasLayerComponent implements AfterViewInit {
     protected set width(width: number) {
         if (this.canvas.width === width) return;
         this.canvas.width = width;
+        this.offscreen.width = width;
         const dpr = window.devicePixelRatio || 1;
         this.ctx?.scale(dpr, dpr);
         this.markAllDrawablesForUpdates();
@@ -54,8 +59,7 @@ export abstract class AbstractCanvasLayerComponent implements AfterViewInit {
     protected set height(height: number) {
         if (this.canvas.height === height) return;
         this.canvas.height = height;
-        const dpr = window.devicePixelRatio || 1;
-        this.ctx?.scale(dpr, dpr);
+        this.offscreen.height = height;
         this.markAllDrawablesForUpdates();
     }
 
@@ -75,8 +79,6 @@ export abstract class AbstractCanvasLayerComponent implements AfterViewInit {
         if (this.canvas.width === width && this.canvas.height === height) return;
         this.width = width;
         this.height = height;
-        const dpr = window.devicePixelRatio || 1;
-        this.ctx?.scale(dpr, dpr);
         this.markAllDrawablesForUpdates();
     }
 
@@ -85,6 +87,10 @@ export abstract class AbstractCanvasLayerComponent implements AfterViewInit {
      */
     public get context(): CanvasRenderingContext2D | null {
         return this.ctx;
+    }
+
+    public get offscreenContext(): OffscreenCanvasRenderingContext2D | null {
+        return this.offscreenCtx;
     }
 
     /**
@@ -181,6 +187,12 @@ export abstract class AbstractCanvasLayerComponent implements AfterViewInit {
     public resetAllDrawablesForUpdates() {
         this.updateDrawableList = [];
         this.forceClear = false;
+    }
+
+    protected repaintCanvas() {
+        const image = this.offscreen.transferToImageBitmap();
+        this.context!.drawImage(image, 0, 0);
+        image.close();
     }
 
     /**

--- a/src/app/components/canvas-layers/active-component-canvas-layer/active-component-canvas-layer.component.ts
+++ b/src/app/components/canvas-layers/active-component-canvas-layer/active-component-canvas-layer.component.ts
@@ -1,4 +1,4 @@
-import type { ElementRef} from '@angular/core';
+import type { ElementRef } from '@angular/core';
 import { Component, ViewChild, inject } from '@angular/core';
 import { AbstractCanvasLayerComponent } from '../abstract-canvas-layer.component';
 import type { Drawable, DrawState } from '../../../models/Drawable';
@@ -15,25 +15,35 @@ import { RenderService } from '../../../services/render/render.service';
 export class ActiveComponentCanvasLayerComponent extends AbstractCanvasLayerComponent {
     private renderService = inject(RenderService);
 
-    @ViewChild('canvas') canvasRef?: ElementRef<HTMLCanvasElement>;
+    @ViewChild('canvas') canvasRef!: ElementRef<HTMLCanvasElement>;
 
     override ngAfterViewInit(): void {
-        this.initCanvas(this.canvasRef!);
+        const width = this.canvasRef.nativeElement.width;
+        const height = this.canvasRef.nativeElement.height;
+        this.initCanvas(new OffscreenCanvas(width, height), this.canvasRef);
     }
 
     override refresh(drawState: DrawState) {
-        if (this.context === null) {
+        if (this.offscreenContext === null) {
             console.warn('Active component context is null: Skipping refresh.');
             this.resetAllDrawablesForUpdates();
             return;
         }
         const updateDrawables: Drawable[] = this.getUpdateDrawablesList();
-        if (this.forceClear) this.context.clearRect(0, 0, this.width, this.height);
-        this.context.strokeStyle = 'blue';
-        this.context.lineWidth = this.renderService.BOLD_LINE_WIDTH;
-        this.context.beginPath();
-        updateDrawables.forEach(d => d.draw(this.context!, drawState));
-        this.context.stroke();
+        if (this.forceClear) {
+            this.offscreenContext.clearRect(0, 0, this.width, this.height);
+            this.context?.clearRect(0, 0, this.width, this.height);
+            const dpr = window.devicePixelRatio || 1;
+            this.offscreenContext.scale(dpr, dpr);
+            this.context?.scale(dpr, dpr);
+        }
+        if (updateDrawables.length === 0) return;
+        this.offscreenContext.strokeStyle = 'blue';
+        this.offscreenContext.lineWidth = this.renderService.BOLD_LINE_WIDTH;
+        this.offscreenContext.beginPath();
+        updateDrawables.forEach(d => d.draw(this.offscreenContext!, drawState));
+        this.offscreenContext.stroke();
+        this.repaintCanvas();
         this.resetAllDrawablesForUpdates();
     }
 }

--- a/src/app/components/canvas-layers/active-wire-canvas-layer/active-wire-canvas-layer.component.ts
+++ b/src/app/components/canvas-layers/active-wire-canvas-layer/active-wire-canvas-layer.component.ts
@@ -1,4 +1,4 @@
-import type { ElementRef} from '@angular/core';
+import type { ElementRef } from '@angular/core';
 import { Component, ViewChild, inject } from '@angular/core';
 import { AbstractCanvasLayerComponent } from '../abstract-canvas-layer.component';
 import type { Drawable, DrawState } from '../../../models/Drawable';
@@ -15,25 +15,35 @@ import { RenderService } from '../../../services/render/render.service';
 export class ActiveWireCanvasLayerComponent extends AbstractCanvasLayerComponent {
     private renderService = inject(RenderService);
 
-    @ViewChild('canvas') canvasRef?: ElementRef<HTMLCanvasElement>;
+    @ViewChild('canvas') canvasRef!: ElementRef<HTMLCanvasElement>;
 
     override ngAfterViewInit(): void {
-        this.initCanvas(this.canvasRef!);
+        const width = this.canvasRef.nativeElement.width;
+        const height = this.canvasRef.nativeElement.height;
+        this.initCanvas(new OffscreenCanvas(width, height), this.canvasRef);
     }
 
     override refresh(drawState: DrawState) {
-        if (this.context === null) {
-            console.warn('Active wire component context is null: Skipping refresh.');
+        if (this.offscreenContext === null) {
+            console.warn('Active wire component offscreenContext is null: Skipping refresh.');
             this.resetAllDrawablesForUpdates();
             return;
         }
         const updateDrawables: Drawable[] = this.getUpdateDrawablesList();
-        if (this.forceClear) this.context.clearRect(0, 0, this.width, this.height);
-        this.context.strokeStyle = 'blue';
-        this.context.lineWidth = this.renderService.BOLD_LINE_WIDTH;
-        this.context.beginPath();
-        updateDrawables.forEach(d => d.draw(this.context!, drawState));
-        this.context.stroke();
+        if (this.forceClear) {
+            this.offscreenContext.clearRect(0, 0, this.width, this.height);
+            this.context?.clearRect(0, 0, this.width, this.height);
+            const dpr = window.devicePixelRatio || 1;
+            this.offscreenContext.scale(dpr, dpr);
+            this.context?.scale(dpr, dpr);
+        }
+        if (updateDrawables.length === 0) return;
+        this.offscreenContext.strokeStyle = 'blue';
+        this.offscreenContext.lineWidth = this.renderService.BOLD_LINE_WIDTH;
+        this.offscreenContext.beginPath();
+        updateDrawables.forEach(d => d.draw(this.offscreenContext!, drawState));
+        this.offscreenContext.stroke();
+        this.repaintCanvas();
         this.resetAllDrawablesForUpdates();
     }
 }

--- a/src/app/components/canvas-layers/component-canvas-layer/component-canvas-layer.component.ts
+++ b/src/app/components/canvas-layers/component-canvas-layer/component-canvas-layer.component.ts
@@ -1,4 +1,4 @@
-import type { ElementRef} from '@angular/core';
+import type { ElementRef } from '@angular/core';
 import { Component, ViewChild, inject } from '@angular/core';
 import { AbstractCanvasLayerComponent } from '../abstract-canvas-layer.component';
 import type { Drawable, DrawState } from '../../../models/Drawable';
@@ -15,25 +15,35 @@ import { RenderService } from '../../../services/render/render.service';
 export class ComponentCanvasLayerComponent extends AbstractCanvasLayerComponent {
     private renderService = inject(RenderService);
 
-    @ViewChild('canvas') canvasRef?: ElementRef<HTMLCanvasElement>;
+    @ViewChild('canvas') canvasRef!: ElementRef<HTMLCanvasElement>;
 
     override ngAfterViewInit(): void {
-        this.initCanvas(this.canvasRef!);
+        const width = this.canvasRef.nativeElement.width;
+        const height = this.canvasRef.nativeElement.height;
+        this.initCanvas(new OffscreenCanvas(width, height), this.canvasRef);
     }
-    
+
     override refresh(drawState: DrawState) {
-        if (this.context === null) {
-            console.warn('Component context is null: Skipping refresh.');
+        if (this.offscreenContext === null) {
+            console.warn('Component offscreenContext is null: Skipping refresh.');
             this.resetAllDrawablesForUpdates();
             return;
         }
         const updateDrawables: Drawable[] = this.getUpdateDrawablesList();
-        if (this.forceClear) this.context.clearRect(0, 0, this.width, this.height);
-        this.context.strokeStyle = 'black';
-        this.context.lineWidth = this.renderService.STANDARD_LINE_WIDTH;
-        this.context.beginPath();
-        updateDrawables.forEach(d => d.draw(this.context!, drawState));
-        this.context.stroke();
+        if (this.forceClear) {
+            this.offscreenContext.clearRect(0, 0, this.width, this.height);
+            this.context?.clearRect(0, 0, this.width, this.height);
+            const dpr = window.devicePixelRatio || 1;
+            this.offscreenContext.scale(dpr, dpr);
+            this.context?.scale(dpr, dpr);
+        }
+        if (updateDrawables.length === 0) return;
+        this.offscreenContext.strokeStyle = 'black';
+        this.offscreenContext.lineWidth = this.renderService.STANDARD_LINE_WIDTH;
+        this.offscreenContext.beginPath();
+        updateDrawables.forEach(d => d.draw(this.offscreenContext!, drawState));
+        this.offscreenContext.stroke();
+        this.repaintCanvas();
         this.resetAllDrawablesForUpdates();
     }
 }

--- a/src/app/components/canvas-layers/grid-canvas-layer/grid-canvas-layer.component.ts
+++ b/src/app/components/canvas-layers/grid-canvas-layer/grid-canvas-layer.component.ts
@@ -22,8 +22,8 @@ export class GridCanvasLayerComponent extends AbstractCanvasLayerComponent {
     private _gridMode?: GridMode;
     private _gridSpacing?: number;
 
-    @ViewChild('canvas') canvasRef?: ElementRef<HTMLCanvasElement>;
-    
+    @ViewChild('canvas') canvasRef!: ElementRef<HTMLCanvasElement>;
+
     @Input()
     set gridSettings(settings: GridSettingsState | null | undefined) {
         if (!settings) {
@@ -46,12 +46,12 @@ export class GridCanvasLayerComponent extends AbstractCanvasLayerComponent {
     get gridSpacing(): number | undefined {
         return this._gridSpacing;
     }
-    
+
     set gridSpacing(spacing: number | null) {
         this._gridSpacing = spacing ?? 20;
         this.onGridSpacingChanged(spacing);
     }
- 
+
     constructor() {
         super();
         const mode = this.gridMode ?? 'dots';
@@ -61,24 +61,33 @@ export class GridCanvasLayerComponent extends AbstractCanvasLayerComponent {
     }
 
     override ngAfterViewInit(): void {
-        this.initCanvas(this.canvasRef!);
+        const width = this.canvasRef.nativeElement.width;
+        const height = this.canvasRef.nativeElement.height;
+        this.initCanvas(new OffscreenCanvas(width, height), this.canvasRef);
     }
 
     override refresh(drawState: DrawState) {
-        // console.log(this.canvasRef?.nativeElement.clientWidth);
-        if (this.context === null) {
-            console.warn('Grid context is null: Skipping refresh.');
+        if (this.offscreenContext === null) {
+            console.warn('Grid offscreenContext is null: Skipping refresh.');
             this.resetAllDrawablesForUpdates();
             return;
         }
         const updateDrawables: Drawable[] = this.getUpdateDrawablesList();
-        // console.log(updateDrawables.length);
-        if (this.forceClear) this.context.clearRect(0, 0, this.width, this.height);
-        this.context.strokeStyle = 'black';
-        this.context.lineWidth = this.renderService.THIN_LINE_WIDTH;
-        this.context.beginPath();
-        updateDrawables.forEach(d => d.draw(this.context!, drawState));
-        this.context.stroke();
+        if (this.forceClear) {
+            this.offscreenContext.clearRect(0, 0, this.width, this.height);
+            this.context?.clearRect(0, 0, this.width, this.height);
+            const dpr = window.devicePixelRatio || 1;
+            this.offscreenContext.scale(dpr, dpr);
+            this.context?.scale(dpr, dpr);
+        }
+        if (updateDrawables.length === 0) return;
+        this.offscreenContext.strokeStyle = 'black';
+        this.offscreenContext.lineWidth = this.renderService.THIN_LINE_WIDTH;
+        this.offscreenContext.beginPath();
+        updateDrawables.forEach(d => d.draw(this.offscreenContext!, drawState));
+        this.offscreenContext.stroke();
+        // console.log('repaint');
+        this.repaintCanvas();
         this.resetAllDrawablesForUpdates();
     }
 

--- a/src/app/components/canvas-layers/io-canvas-layer/io-canvas-layer.component.ts
+++ b/src/app/components/canvas-layers/io-canvas-layer/io-canvas-layer.component.ts
@@ -1,4 +1,4 @@
-import type { ElementRef} from '@angular/core';
+import type { ElementRef } from '@angular/core';
 import { Component, ViewChild, inject } from '@angular/core';
 import { AbstractCanvasLayerComponent } from '../abstract-canvas-layer.component';
 import type { Drawable, DrawState } from '../../../models/Drawable';
@@ -15,25 +15,35 @@ import { RenderService } from '../../../services/render/render.service';
 export class IOCanvasLayerComponent extends AbstractCanvasLayerComponent {
     private renderService = inject(RenderService);
 
-    @ViewChild('canvas') canvasRef?: ElementRef<HTMLCanvasElement>;
+    @ViewChild('canvas') canvasRef!: ElementRef<HTMLCanvasElement>;
 
     override ngAfterViewInit(): void {
-        this.initCanvas(this.canvasRef!);
+        const width = this.canvasRef.nativeElement.width;
+        const height = this.canvasRef.nativeElement.height;
+        this.initCanvas(new OffscreenCanvas(width, height), this.canvasRef);
     }
 
     override refresh(drawState: DrawState) {
-        if (this.context === null) {
+        if (this.offscreenContext === null) {
             console.warn('IO context is null: Skipping refresh.');
             this.resetAllDrawablesForUpdates();
             return;
         }
         const updateDrawables: Drawable[] = this.getUpdateDrawablesList();
-        if (this.forceClear) this.context.clearRect(0, 0, this.width, this.height);
-        this.context.strokeStyle = 'black';
-        this.context.lineWidth = this.renderService.STANDARD_LINE_WIDTH;
-        this.context.beginPath();
+        if (this.forceClear) {
+            this.offscreenContext.clearRect(0, 0, this.width, this.height);
+            this.context?.clearRect(0, 0, this.width, this.height);
+            const dpr = window.devicePixelRatio || 1;
+            this.offscreenContext.scale(dpr, dpr);
+            this.context?.scale(dpr, dpr);
+        }
+        if (updateDrawables.length === 0) return;
+        this.offscreenContext.strokeStyle = 'black';
+        this.offscreenContext.lineWidth = this.renderService.STANDARD_LINE_WIDTH;
+        this.offscreenContext.beginPath();
         updateDrawables.forEach(d => d.draw(this.context!, drawState));
-        this.context.stroke();
+        this.offscreenContext.stroke();
+        this.repaintCanvas();
         this.resetAllDrawablesForUpdates();
     }
 }

--- a/src/app/components/canvas-layers/wire-canvas-layer/wire-canvas-layer.component.ts
+++ b/src/app/components/canvas-layers/wire-canvas-layer/wire-canvas-layer.component.ts
@@ -1,4 +1,4 @@
-import type { ElementRef} from '@angular/core';
+import type { ElementRef } from '@angular/core';
 import { Component, ViewChild, inject } from '@angular/core';
 import { AbstractCanvasLayerComponent } from '../abstract-canvas-layer.component';
 import type { Drawable, DrawState } from '../../../models/Drawable';
@@ -15,25 +15,35 @@ import { RenderService } from '../../../services/render/render.service';
 export class WireCanvasLayerComponent extends AbstractCanvasLayerComponent {
     private renderService = inject(RenderService);
 
-    @ViewChild('canvas') canvasRef?: ElementRef<HTMLCanvasElement>;
+    @ViewChild('canvas') canvasRef!: ElementRef<HTMLCanvasElement>;
 
     override ngAfterViewInit(): void {
-        this.initCanvas(this.canvasRef!);
+        const width = this.canvasRef.nativeElement.width;
+        const height = this.canvasRef.nativeElement.height;
+        this.initCanvas(new OffscreenCanvas(width, height), this.canvasRef!);
     }
 
     override refresh(drawState: DrawState) {
-        if (this.context === null) {
-            console.warn('Wire context is null: Skipping refresh.');
+        if (this.offscreenContext === null) {
+            console.warn('Wire offscreenContext is null: Skipping refresh.');
             this.resetAllDrawablesForUpdates();
             return;
         }
         const updateDrawables: Drawable[] = this.getUpdateDrawablesList();
-        if (this.forceClear) this.context.clearRect(0, 0, this.width, this.height);
-        this.context.strokeStyle = 'black';
-        this.context.lineWidth = this.renderService.STANDARD_LINE_WIDTH;
-        this.context.beginPath();
-        updateDrawables.forEach(d => d.draw(this.context!, drawState));
-        this.context.stroke();
+        if (this.forceClear) {
+            this.offscreenContext.clearRect(0, 0, this.width, this.height);
+            this.context?.clearRect(0, 0, this.width, this.height);
+            const dpr = window.devicePixelRatio || 1;
+            this.offscreenContext.scale(dpr, dpr);
+            this.context?.scale(dpr, dpr);
+        }
+        if (updateDrawables.length === 0) return;
+        this.offscreenContext.strokeStyle = 'black';
+        this.offscreenContext.lineWidth = this.renderService.STANDARD_LINE_WIDTH;
+        this.offscreenContext.beginPath();
+        updateDrawables.forEach(d => d.draw(this.offscreenContext!, drawState));
+        this.offscreenContext.stroke();
+        this.repaintCanvas();
         this.resetAllDrawablesForUpdates();
     }
 }

--- a/src/app/components/workspace-tabs/workspace-tabs.component.spec.ts
+++ b/src/app/components/workspace-tabs/workspace-tabs.component.spec.ts
@@ -6,10 +6,8 @@ import { WorkspaceTabsComponent } from './workspace-tabs.component';
 import { RenderService } from '../../services/render/render.service';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { provideMockStore } from '@ngrx/store/testing';
+import { resizeObserverInstances } from '../../../../vitest.setup';
 
-const mockObserve = vi.fn();
-const mockUnobserve = vi.fn();
-const mockDisconnect = vi.fn();
 
 describe('WorkspaceTabsComponent', () => {
     let component: WorkspaceTabsComponent;
@@ -27,18 +25,13 @@ describe('WorkspaceTabsComponent', () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         set activeId(_: string) { },
     };
-    let capturedCallback: ResizeObserverCallback;
-    vi.stubGlobal('ResizeObserver', vi.fn().mockImplementation((cb) => {
-        capturedCallback = cb;
-        return {
-            observe: mockObserve,
-            unobserve: mockUnobserve,
-            disconnect: mockDisconnect,
-        };
-    }));
+
     const buildEntry = (width: number, height: number): ResizeObserverEntry => ({
         contentRect: { width, height } as DOMRectReadOnly
     } as ResizeObserverEntry);
+
+    // convenience getter — this component creates one observer, so index 0
+    const observer = () => resizeObserverInstances[0];
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
@@ -50,9 +43,11 @@ describe('WorkspaceTabsComponent', () => {
             schemas: [NO_ERRORS_SCHEMA]
         }).compileComponents();
 
-        vi.clearAllMocks();
-        mockRenderService.getActiveDiagramWidth.mockReturnValue(initialWidth);
-        mockRenderService.getActiveDiagramHeight.mockReturnValue(initialHeight);
+        mockRenderService.getActiveDiagramWidth.mockClear().mockReturnValue(initialWidth);
+        mockRenderService.getActiveDiagramHeight.mockClear().mockReturnValue(initialHeight);
+        mockRenderService.start.mockClear();
+        mockRenderService.stop.mockClear();
+        mockRenderService.resizeActiveDiagram.mockClear();
 
         fixture = TestBed.createComponent(WorkspaceTabsComponent);
         component = fixture.componentInstance;
@@ -65,39 +60,39 @@ describe('WorkspaceTabsComponent', () => {
 
     describe('onViewportResize', () => {
         it('should call resizeActiveDiagram when viewport is wider than current render width', () => {
-            capturedCallback([buildEntry(initialWidth + 1, initialHeight)], null!);
+            observer().callback([buildEntry(initialWidth + 1, initialHeight)], null!);
             expect(mockRenderService.resizeActiveDiagram).toHaveBeenCalled();
         });
 
         it('should not call resizeActiveDiagram when viewport is narrower than current render width', () => {
-            capturedCallback([buildEntry(initialWidth - 1, initialHeight)], null!);
+            observer().callback([buildEntry(initialWidth - 1, initialHeight)], null!);
             expect(mockRenderService.resizeActiveDiagram).not.toHaveBeenCalled();
         });
 
         it('should not call resizeActiveDiagram when viewport matches current render dimensions', () => {
-            capturedCallback([buildEntry(initialWidth, initialHeight)], null!);
+            observer().callback([buildEntry(initialWidth, initialHeight)], null!);
             expect(mockRenderService.resizeActiveDiagram).not.toHaveBeenCalled();
         });
 
         it('should call resizeActiveDiagram when viewport is taller than current render height', () => {
-            capturedCallback([buildEntry(initialWidth, initialHeight + 1)], null!);
+            observer().callback([buildEntry(initialWidth, initialHeight + 1)], null!);
             expect(mockRenderService.resizeActiveDiagram).toHaveBeenCalled();
         });
 
         it('should not call resizeActiveDiagram when viewport is shorter than current render height', () => {
-            capturedCallback([buildEntry(initialWidth, initialHeight - 1)], null!);
+            observer().callback([buildEntry(initialWidth, initialHeight - 1)], null!);
             expect(mockRenderService.resizeActiveDiagram).not.toHaveBeenCalled();
         });
 
         it('should grow width when viewport is wider than current render width', () => {
-            capturedCallback([buildEntry(initialWidth + 1, initialHeight)], null!);
+            observer().callback([buildEntry(initialWidth + 1, initialHeight)], null!);
             const [newWidth, newHeight] = mockRenderService.resizeActiveDiagram.mock.calls[0];
             expect(newWidth).toBeGreaterThan(initialWidth);
             expect(newHeight).toBe(initialHeight);
         });
 
         it('should grow height when viewport is taller than current render height', () => {
-            capturedCallback([buildEntry(initialWidth, initialHeight + 1)], null!);
+            observer().callback([buildEntry(initialWidth, initialHeight + 1)], null!);
             const [newWidth, newHeight] = mockRenderService.resizeActiveDiagram.mock.calls[0];
             expect(newWidth).toBe(initialWidth);
             expect(newHeight).toBeGreaterThan(initialHeight);
@@ -107,20 +102,20 @@ describe('WorkspaceTabsComponent', () => {
     describe('Resize observer', () => {
         it('should observe the first contentViewport element for resizing on init', () => {
             const firstViewport = component.viewports?.get(0)?.nativeElement;
-            expect(mockObserve).toHaveBeenCalledWith(firstViewport);
+            expect(observer().observe).toHaveBeenCalledWith(firstViewport);
         });
 
         it('should unobserve and re-observe the new viewport element when the active tab changes', () => {
             const firstViewport = component.viewports?.get(0)?.nativeElement;
             const secondViewport = component.viewports?.get(1)?.nativeElement;
             component['changeActiveWorkspace']({ id: 'some-uuid', index: 1 });
-            expect(mockUnobserve).toHaveBeenCalledWith(firstViewport);
-            expect(mockObserve).toHaveBeenCalledWith(secondViewport);
+            expect(observer().unobserve).toHaveBeenCalledWith(firstViewport);
+            expect(observer().observe).toHaveBeenCalledWith(secondViewport);
         });
 
         it('should disconnect on destroy', () => {
             fixture.destroy();
-            expect(mockDisconnect).toHaveBeenCalledOnce();
+            expect(observer().disconnect).toHaveBeenCalledOnce();
         });
     });
 

--- a/src/app/components/xorls-tabview/xorls-tabview.component.spec.ts
+++ b/src/app/components/xorls-tabview/xorls-tabview.component.spec.ts
@@ -23,17 +23,25 @@ import { XorlsTabviewComponent, DraggableTabComponent } from './xorls-tabview.co
         </app-xorls-tab-view>
     `
 })
-class TestHostComponent {}
+class TestHostComponent { }
 
 @Component({
     selector: 'app-empty-host',
     imports: [XorlsTabviewComponent],
     template: `<app-xorls-tab-view />`
 })
-class EmptyHostComponent {}
+class EmptyHostComponent { }
 
 const getTabviewInstance = (fixture: ComponentFixture<unknown>): XorlsTabviewComponent =>
     fixture.debugElement.query(By.directive(XorlsTabviewComponent)).componentInstance;
+
+const finishLatestAnimation = () => {
+    const animateMock = vi.mocked(Element.prototype.animate);
+    const results = animateMock.mock.results;
+    const latest = results[results.length - 1];
+    const animation = latest.value as Animation & { finish: () => void };
+    animation.finish();
+};
 
 describe('XorlsTabviewComponent', () => {
     describe('with tabs', () => {
@@ -154,12 +162,11 @@ describe('XorlsTabviewComponent', () => {
         });
 
         describe('onClose', () => {
-            beforeAll(() => {
-                HTMLElement.prototype.animate = vi.fn().mockImplementation(() => {
-                    const animation = { onfinish: null as (() => void) | null };
-                    Promise.resolve().then(() => animation.onfinish?.());
-                    return animation as unknown as Animation;
-                });
+            it('should call animate on the closing tab element', () => {
+                const closeBtns = fixture.debugElement.queryAll(By.css('.close-btn'));
+                closeBtns[0].nativeElement.click();
+
+                expect(Element.prototype.animate).toHaveBeenCalledTimes(1);
             });
 
             it('should emit tabClose with the closed tab index', async () => {
@@ -168,6 +175,7 @@ describe('XorlsTabviewComponent', () => {
 
                 const closeBtns = fixture.debugElement.queryAll(By.css('.close-btn'));
                 closeBtns[1].nativeElement.click();
+                finishLatestAnimation();
                 await fixture.whenStable();
 
                 expect(emitSpy).toHaveBeenCalledWith(1);
@@ -178,6 +186,7 @@ describe('XorlsTabviewComponent', () => {
 
                 const closeBtns = fixture.debugElement.queryAll(By.css('.close-btn'));
                 closeBtns[0].nativeElement.click();
+                finishLatestAnimation();
                 await fixture.whenStable();
                 fixture.detectChanges();
 
@@ -190,6 +199,7 @@ describe('XorlsTabviewComponent', () => {
 
                 const closeBtns = fixture.debugElement.queryAll(By.css('.close-btn'));
                 closeBtns[0].nativeElement.click();
+                finishLatestAnimation();
                 await fixture.whenStable();
 
                 expect(tabview['activeIndex']).toBe(1);
@@ -201,20 +211,10 @@ describe('XorlsTabviewComponent', () => {
 
                 const closeBtns = fixture.debugElement.queryAll(By.css('.close-btn'));
                 closeBtns[0].nativeElement.click();
+                finishLatestAnimation();
                 await fixture.whenStable();
 
                 expect(tabview['activeIndex']).toBeGreaterThanOrEqual(0);
-            });
-
-            it('should call animate on the closing tab element', () => {
-                const animateSpy = vi.spyOn(HTMLElement.prototype, 'animate').mockReturnValue({
-                    onfinish: null,
-                } as unknown as Animation);
-
-                const closeBtns = fixture.debugElement.queryAll(By.css('.close-btn'));
-                closeBtns[0].nativeElement.click();
-
-                expect(animateSpy).toHaveBeenCalledTimes(1);
             });
         });
     });

--- a/src/app/models/Drawable.ts
+++ b/src/app/models/Drawable.ts
@@ -7,5 +7,5 @@ export interface DrawState {
 }
 
 export interface Drawable {
-    draw(ctx: CanvasRenderingContext2D, state: DrawState): void;
+    draw(ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D, state: DrawState): void;
 }

--- a/src/app/services/render/render.service.spec.ts
+++ b/src/app/services/render/render.service.spec.ts
@@ -262,7 +262,6 @@ describe('RenderService', () => {
             expect(drawState.scale).toBe(1.5);
         });
     });
-
     describe('resizeActiveDiagram', () => {
         it('should call resize on all active layers with the new dimensions', () => {
             const layerA = buildMockLayer();
@@ -273,6 +272,18 @@ describe('RenderService', () => {
 
             expect(layerA.resize).toHaveBeenCalledWith(1024, 768);
             expect(layerB.resize).toHaveBeenCalledWith(1024, 768);
+        });
+
+        it('should scale the context of each active layer by the device pixel ratio', () => {
+            const dpr = window.devicePixelRatio || 1;
+            const layerA = buildMockLayer();
+            const layerB = buildMockLayer();
+            service.add('diagramA', [layerA, layerB]);
+            service.activeId = 'diagramA';
+            service.resizeActiveDiagram(1024, 768);
+
+            expect(layerA.context!.scale).toHaveBeenCalledWith(dpr, dpr);
+            expect(layerB.context!.scale).toHaveBeenCalledWith(dpr, dpr);
         });
 
         it('should call refresh on all active layers after resize to prevent flickering', () => {
@@ -286,20 +297,30 @@ describe('RenderService', () => {
             expect(layerB.refresh).toHaveBeenCalledTimes(1);
         });
 
-        it('should call resize before refresh on each layer', () => {
+        it('should call resize, then scale the context, then refresh, in that order', () => {
             const callOrder: string[] = [];
             const layer = buildMockLayer({
                 resize: vi.fn(() => callOrder.push('resize')),
                 refresh: vi.fn(() => callOrder.push('refresh')),
             });
+            (layer.context as unknown as { scale: ReturnType<typeof vi.fn> }).scale =
+                vi.fn(() => callOrder.push('scale'));
             service.add('diagramA', [layer]);
             service.activeId = 'diagramA';
             service.resizeActiveDiagram(800, 600);
 
-            expect(callOrder).toEqual(['resize', 'refresh']);
+            expect(callOrder).toEqual(['resize', 'scale', 'refresh']);
         });
 
-        it('should not call resize or refresh on layers from inactive diagrams', () => {
+        it('should not throw when a layer context is null during resize', () => {
+            const nullLayer = buildMockLayer({ context: null });
+            service.add('diagramA', [nullLayer]);
+            service.activeId = 'diagramA';
+
+            expect(() => service.resizeActiveDiagram(800, 600)).not.toThrow();
+        });
+
+        it('should not call resize, refresh, or scale context on layers from inactive diagrams', () => {
             const inactiveLayer = buildMockLayer();
             const activeLayer = buildMockLayer();
             service.add('diagramA', [inactiveLayer]);
@@ -309,6 +330,7 @@ describe('RenderService', () => {
 
             expect(inactiveLayer.resize).not.toHaveBeenCalled();
             expect(inactiveLayer.refresh).not.toHaveBeenCalled();
+            expect(inactiveLayer.context!.scale).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/app/services/render/render.service.ts
+++ b/src/app/services/render/render.service.ts
@@ -141,6 +141,8 @@ export class RenderService {
             // setting canvas width/height automatically clear the canvas
             // so we need to force a refresh now to prevent flickering
             // due to the canvas being blank until the next draw loop cycle.
+            const dpr = window.devicePixelRatio || 1;
+            l.context?.scale(dpr, dpr);
             l.refresh(this.drawState);
         });
     }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,84 @@
+import { vi, beforeEach, afterEach } from 'vitest';
+
+export interface MockResizeObserverInstance {
+    callback: ResizeObserverCallback;
+    observe: ReturnType<typeof vi.fn>;
+    unobserve: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+}
+
+export const resizeObserverInstances: MockResizeObserverInstance[] = [];
+
+export function buildMockCanvasContext() {
+    return {
+        scale: vi.fn(),
+        clearRect: vi.fn(),
+        drawImage: vi.fn(),
+        beginPath: vi.fn(),
+        stroke: vi.fn(),
+        fillRect: vi.fn(),
+        strokeRect: vi.fn(),
+        strokeStyle: '',
+        fillStyle: '',
+        lineWidth: 0,
+    } as unknown as CanvasRenderingContext2D;
+}
+
+export function buildMockAnimation() {
+    const animation: Partial<Animation> & { onfinish: ((ev: Event) => void) | null } = {
+        onfinish: null,
+        oncancel: null,
+        cancel: vi.fn(),
+        finish: vi.fn(function (this: typeof animation) {
+            this.onfinish?.(new Event('finish'));
+        }),
+        play: vi.fn(),
+        pause: vi.fn(),
+    };
+    return animation as unknown as Animation;
+}
+
+let animateMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+    vi.stubGlobal(
+        'OffscreenCanvas',
+        vi.fn().mockImplementation((width: number, height: number) => ({
+            width,
+            height,
+            getContext: vi.fn(() => buildMockCanvasContext()),
+            transferToImageBitmap: vi.fn(() => ({ close: vi.fn() })),
+        }))
+    );
+    resizeObserverInstances.length = 0;
+
+    vi.stubGlobal(
+        'ResizeObserver',
+        vi.fn().mockImplementation((callback: ResizeObserverCallback) => {
+            const instance: MockResizeObserverInstance = {
+                callback,
+                observe: vi.fn(),
+                unobserve: vi.fn(),
+                disconnect: vi.fn(),
+            };
+            resizeObserverInstances.push(instance);
+            return instance;
+        })
+    );
+
+    animateMock = vi.fn().mockImplementation(() => buildMockAnimation());
+    Element.prototype.animate = animateMock as unknown as typeof Element.prototype.animate;
+
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+        () => buildMockCanvasContext()
+    );
+
+    vi.spyOn(Element.prototype, 'animate').mockImplementation(() => buildMockAnimation());
+});
+
+afterEach(() => {
+    // @ts-expect-error - intentionally clearing a property jsdom may not define
+    delete Element.prototype.animate;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});


### PR DESCRIPTION
add mock canvas, context, animation, resizeobserver to global stubs in vitest.setup.ts.  #17 